### PR TITLE
proof of concept: subitem field

### DIFF
--- a/demiurge/__init__.py
+++ b/demiurge/__init__.py
@@ -4,4 +4,4 @@ __author__ = 'Matias Bordese'
 __email__ = 'mbordese@gmail.com'
 __version__ = '0.1'
 
-from .demiurge import Item, AttributeValueField, TextField, ItemDoesNotExist
+from .demiurge import Item, AttributeValueField, TextField, ItemDoesNotExist, SubItemField

--- a/demiurge/demiurge.py
+++ b/demiurge/demiurge.py
@@ -86,6 +86,19 @@ class AttributeValueField(TextField):
         return value
 
 
+class SubItemField(AttributeValueField):
+
+    def __init__(self, item_model, mode='all', selector=None, attr=None, **kwargs):
+        self.item_model = item_model
+        self.mode = mode
+        self.kwargs = kwargs
+        super(SubItemField, self).__init__(selector, attr)
+
+    def clean(self, value):
+        value = super(SubItemField, self).clean(value)
+        return getattr(self.item_model, self.mode)(value, **self.kwargs)
+
+
 def get_fields(bases, attrs):
     fields = [(field_name, attrs.pop(field_name)) for field_name, obj in
               list(attrs.items()) if isinstance(obj, BaseField)]

--- a/tests/test_demiurge.py
+++ b/tests/test_demiurge.py
@@ -6,6 +6,14 @@ from mock import patch
 
 import demiurge
 
+HTML_INDEX = """
+<html>
+    <body>
+        <a class="link" href="/matilinks">Link text.</a>
+    </body>
+</html>
+"""
+
 
 HTML_SAMPLE = """
 <html>
@@ -30,6 +38,14 @@ class TestItem(demiurge.Item):
         base_url = 'http://localhost'
         selector = "p.p_with_link"
         extra_attribute = 'value'
+
+
+class TestIndexItem(demiurge.Item):
+    matilinks = demiurge.SubItemField(TestItem, attr='href')
+
+    class Meta:
+        base_url = 'http://localhost'
+        selector = "a"
 
 
 class TestDemiurge(unittest.TestCase):
@@ -101,6 +117,16 @@ class TestDemiurge(unittest.TestCase):
         )
         self.assertIsNotNone(item)
         self.assertEqual(item.html, expected)
+
+
+    def test_subitem(self):
+        self.mock_opener.side_effect = [HTML_INDEX, HTML_SAMPLE, HTML_SAMPLE]
+        index = TestIndexItem.one()
+        self.assertEqual(len(index.matilinks), 2)
+        self.assertEqual(index.matilinks[0].label, 'Link text.')
+        self.assertEqual(index.matilinks[0].url, 'http://github.com/matiasb')
+        self.assertEqual(index.matilinks[1].label, 'Another link.')
+        self.assertEqual(index.matilinks[1].url, 'http://github.com/matiasb/demiurge')
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
short rationale: Sometimes I need to scrap a page to retrieve the actual links where the items are. 
I would like a way to nest Item classes, analog (in some way) to a in ForeignKey / ManyToManyField in Django.   

This is a first PR as a proof of concept, to discuss the idea and its API.  
