### PR TITLE
Reausable cleaning functions

### DIFF
--- a/demiurge/demiurge.py
+++ b/demiurge/demiurge.py
@@ -26,8 +26,13 @@ def with_metaclass(meta, base=object):
 class BaseField(object):
     """Base demiurge field."""
 
+    def __init__(self, filter=None):
+        self.fitler=filter
+
     def clean(self, value):
         """Clean extracted value."""
+        if self.filter:
+            return self.filter(value)
         return value
 
     def get_value(self, pq):
@@ -45,7 +50,7 @@ class TextField(BaseField):
 
     """
 
-    def __init__(self, selector=None):
+    def __init__(self, selector=None, **kwargs):
         super(TextField, self).__init__()
         self.selector = selector
 

--- a/demiurge/demiurge.py
+++ b/demiurge/demiurge.py
@@ -26,13 +26,13 @@ def with_metaclass(meta, base=object):
 class BaseField(object):
     """Base demiurge field."""
 
-    def __init__(self, filter=None):
-        self.fitler=filter
+    def __init__(self, clean=None):
+        self.cleanFunc=clean
 
     def clean(self, value):
         """Clean extracted value."""
-        if self.filter:
-            return self.filter(value)
+        if self.cleanFunc:
+            return self.cleanFunc(value)
         return value
 
     def get_value(self, pq):
@@ -50,8 +50,8 @@ class TextField(BaseField):
 
     """
 
-    def __init__(self, selector=None, **kwargs):
-        super(TextField, self).__init__()
+    def __init__(self, selector=None, clean=None):
+        super(TextField, self).__init__(clean=clean)
         self.selector = selector
 
     def clean(self, value):
@@ -80,8 +80,8 @@ class AttributeValueField(TextField):
 
     """
 
-    def __init__(self, selector=None, attr=None):
-        super(AttributeValueField, self).__init__(selector=selector)
+    def __init__(self, selector=None, attr=None, clean=None):
+        super(AttributeValueField, self).__init__(selector=selector, clean=clean)
         self.attr = attr
 
     def get_value(self, pq):

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -169,6 +169,12 @@ self-relate an Item with itself, you should use the 'self' parameter::
         next_page = demiurge.RelatedItem('self', selector='...', attr='...')
 
 
+You can also specify a cleaing function in a keyword argument. 
+For example if value needed to be an int, you could do::
+
+    value = demiurge.TextField(clean=int)
+
+to use pythons build in "int()" function on it.
 
 Why *demiurge*?
 ---------------


### PR DESCRIPTION
You can now add a "clean" kwarg containing a function to a field.

This makes it easy to use quick filtering (I want this data to be an int) and to re-use functions such as [parsedatetime](https://pypi.python.org/pypi/parsedatetime/).

```python
    score = demiurge.TextField(selector=".score .upvoted", clean=int)
```